### PR TITLE
Add usage page links and hide tools for admin

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -99,6 +99,7 @@
             <a href="index.html">トップページ</a>
             <a href="privacy.html">プライバシーポリシー</a>
             <a href="terms.html">利用規約</a>
+            <a href="usage.html">使い方</a>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -527,7 +527,7 @@
 
 
             <!-- Affiliate Recommendations -->
-            <div class="bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-8 mb-8">
+            <div id="affiliateRecommendations" class="bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-8 mb-8">
                 <h3 class="text-xl font-bold text-gray-900 mb-4 text-center">医療機関向けおすすめツール</h3>
                 <div class="grid md:grid-cols-3 gap-6">
                     <div class="bg-white rounded-lg p-6 card-shadow">
@@ -570,6 +570,7 @@
                         <div><a href="privacy.html" class="hover:text-white">プライバシーポリシー</a></div>
                         <div><a href="terms.html" class="hover:text-white">免責事項</a></div>
                         <div><a href="contact.html" class="hover:text-white">お問い合わせ</a></div>
+                        <div><a href="usage.html" class="hover:text-white">使い方</a></div>
                     </div>
                 </div>
                 <div>
@@ -793,6 +794,7 @@
                 isAdminLoggedIn = true;
                 document.getElementById('adminLogin').classList.add('hidden');
                 document.getElementById('adminDashboard').classList.remove('hidden');
+                document.getElementById('affiliateRecommendations').classList.add('hidden');
                 loadAdminData();
             } else {
                 alert('ログイン情報が正しくありません。');
@@ -803,6 +805,7 @@
             isAdminLoggedIn = false;
             document.getElementById('adminLogin').classList.remove('hidden');
             document.getElementById('adminDashboard').classList.add('hidden');
+            document.getElementById('affiliateRecommendations').classList.remove('hidden');
             document.getElementById('adminLoginForm').reset();
         }
 

--- a/privacy.html
+++ b/privacy.html
@@ -66,6 +66,7 @@
             <a href="index.html">トップページ</a>
             <a href="terms.html">利用規約</a>
             <a href="contact.html">お問い合わせ</a>
+            <a href="usage.html">使い方</a>
         </div>
     </div>
 </body>

--- a/terms.html
+++ b/terms.html
@@ -70,6 +70,7 @@
             <a href="index.html">トップページ</a>
             <a href="privacy.html">プライバシーポリシー</a>
             <a href="contact.html">お問い合わせ</a>
+            <a href="usage.html">使い方</a>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- link to `usage.html` from all footers
- add ID for affiliate recommendations and hide them when admin logs in

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cf2acf378832eb61c337699a93416