### PR TITLE
Add Supabase integration and persist admin login

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ MediBookは、医療記録を簡単に管理できるPWA（Progressive Web App�
 - オフライン対応
 - モバイルフレンドリーなUI
 - セキュアなデータ管理
+- Supabaseを利用した予約情報のクラウド保存（無料プランで運用可能）
 
 ## 技術スタック
 
@@ -65,6 +66,13 @@ medibook/
 ## 使い方
 
 基本的な操作方法については[使い方ページ](usage.html)を参照してください。
+
+## データベース設定
+
+予約データは [Supabase](https://supabase.com/) の無料プランで保存できます。
+`index.html` と `admin/index.html` の `SUPABASE_URL` と `SUPABASE_ANON_KEY` を
+ご自身のプロジェクト情報に置き換えてください。無料枠の範囲内であれば
+月額0円（100円未満）で利用可能です。
 
 ## ライセンス
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -96,6 +96,7 @@
             box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1);
         }
     </style>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body class="bg-gray-50 font-sans">
     <!-- Google Tag Manager (noscript) -->
@@ -571,8 +572,12 @@
     </footer>
 
     <script>
+        const SUPABASE_URL = 'YOUR_SUPABASE_URL';
+        const SUPABASE_KEY = 'YOUR_SUPABASE_ANON_KEY';
+        const sb = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+
         // Data Storage
-        let appointments = JSON.parse(localStorage.getItem('medibook_appointments') || '[]');
+        let appointments = [];
         let slotCapacities = JSON.parse(localStorage.getItem('medibook_slot_capacities') || '{}');
         let currentAppointment = null;
         let isAdminLoggedIn = false;
@@ -597,11 +602,22 @@
         // Utility Functions
         function generateId() {
             const date = new Date();
-            const dateStr = date.getFullYear().toString() + 
-                           (date.getMonth() + 1).toString().padStart(2, '0') + 
+            const dateStr = date.getFullYear().toString() +
+                           (date.getMonth() + 1).toString().padStart(2, '0') +
                            date.getDate().toString().padStart(2, '0');
             const random = Math.floor(Math.random() * 10000).toString().padStart(4, '0');
             return `MB${dateStr}${random}`;
+        }
+
+        async function fetchAppointments() {
+            const { data, error } = await sb.from('appointments').select('*');
+            if (!error) {
+                appointments = data || [];
+                saveData();
+            } else {
+                console.error(error);
+                appointments = JSON.parse(localStorage.getItem('medibook_appointments') || '[]');
+            }
         }
 
         function saveData() {
@@ -717,6 +733,9 @@
             appointments.push(formData);
             saveData();
             updateStats();
+            sb.from('appointments').insert([formData]).then(({ error }) => {
+                if (error) console.error(error);
+            });
 
             // Show confirmation
             alert(`予約が送信されました。管理者の承認をお待ちください。\n\n予約ID: ${formData.id}\n日時: ${formData.date} ${formData.time}\n\n予約IDは必ずメモしてください。`);
@@ -776,7 +795,7 @@
         });
 
         // Admin Functions
-        document.getElementById('adminLoginForm').addEventListener('submit', function(e) {
+        document.getElementById('adminLoginForm').addEventListener('submit', async function(e) {
             e.preventDefault();
             
             const id = document.getElementById('adminId').value;
@@ -785,13 +804,14 @@
             // Simple authentication (in production, use proper authentication)
             if (id === 'admin' && password === 'password') {
                 isAdminLoggedIn = true;
+                localStorage.setItem('medibook_admin_login', 'true');
                 document.getElementById('adminLogin').classList.add('hidden');
                 document.getElementById('adminDashboard').classList.remove('hidden');
                 const affiliateElem = document.getElementById('affiliateRecommendations');
                 if (affiliateElem) {
                     affiliateElem.classList.add('hidden');
                 }
-                loadAdminData();
+                await loadAdminData();
             } else {
                 alert('ログイン情報が正しくありません。');
             }
@@ -799,6 +819,7 @@
 
         function adminLogout() {
             isAdminLoggedIn = false;
+            localStorage.removeItem('medibook_admin_login');
             document.getElementById('adminLogin').classList.remove('hidden');
             document.getElementById('adminDashboard').classList.add('hidden');
             const affiliateElem = document.getElementById('affiliateRecommendations');
@@ -808,7 +829,8 @@
             document.getElementById('adminLoginForm').reset();
         }
 
-      function loadAdminData() {
+      async function loadAdminData() {
+          await fetchAppointments();
           updateStats();
           loadAppointmentTable();
           loadAnalyticsChart();
@@ -877,6 +899,9 @@
             if (appointment) {
                 appointment.status = newStatus;
                 saveData();
+                sb.from('appointments').update({status: newStatus}).eq('id', appointmentId).then(({ error }) => {
+                    if (error) console.error(error);
+                });
                 loadAdminData();
             }
         }
@@ -1077,10 +1102,16 @@
         }
 
         // Initialize
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', async function() {
             const savedSize = parseInt(localStorage.getItem('medibook_fontsize'));
             if (savedSize) {
                 setBaseFontSize(savedSize);
+            }
+            if (localStorage.getItem('medibook_admin_login') === 'true') {
+                isAdminLoggedIn = true;
+                document.getElementById('adminLogin').classList.add('hidden');
+                document.getElementById('adminDashboard').classList.remove('hidden');
+                await loadAdminData();
             }
             const monthInput = document.getElementById('calendarMonth');
             const today = new Date();
@@ -1099,7 +1130,7 @@
             updateStats();
             showSection('admin');
             setInterval(updateTime, 60000); // Update time every minute
-            setInterval(updateStats, 300000); // Update stats every 5 minutes
+            setInterval(async () => { await loadAdminData(); }, 300000); // every 5 minutes
         });
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -95,7 +95,8 @@
             transform: translateY(-2px);
             box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1);
         }
-    </style>
+</style>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body class="bg-gray-50 font-sans">
     <!-- Google Tag Manager (noscript) -->
@@ -449,8 +450,12 @@
     </footer>
 
     <script>
+        const SUPABASE_URL = 'YOUR_SUPABASE_URL';
+        const SUPABASE_KEY = 'YOUR_SUPABASE_ANON_KEY';
+        const sb = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+
         // Data Storage
-        let appointments = JSON.parse(localStorage.getItem('medibook_appointments') || '[]');
+        let appointments = [];
         let currentAppointment = null;
         let baseFontSize = parseInt(getComputedStyle(document.documentElement).fontSize);
 
@@ -473,11 +478,22 @@
         // Utility Functions
         function generateId() {
             const date = new Date();
-            const dateStr = date.getFullYear().toString() + 
-                           (date.getMonth() + 1).toString().padStart(2, '0') + 
+            const dateStr = date.getFullYear().toString() +
+                           (date.getMonth() + 1).toString().padStart(2, '0') +
                            date.getDate().toString().padStart(2, '0');
             const random = Math.floor(Math.random() * 10000).toString().padStart(4, '0');
             return `MB${dateStr}${random}`;
+        }
+
+        async function fetchAppointments() {
+            const { data, error } = await sb.from('appointments').select('*');
+            if (!error) {
+                appointments = data || [];
+                saveData();
+            } else {
+                console.error(error);
+                appointments = JSON.parse(localStorage.getItem('medibook_appointments') || '[]');
+            }
         }
 
         function saveData() {
@@ -576,6 +592,9 @@
             appointments.push(formData);
             saveData();
             updateStats();
+            sb.from('appointments').insert([formData]).then(({ error }) => {
+                if (error) console.error(error);
+            });
 
             // Show confirmation
             alert(`予約が送信されました。管理者の承認をお待ちください。\n\n予約ID: ${formData.id}\n日時: ${formData.date} ${formData.time}\n\n予約IDは必ずメモしてください。`);
@@ -711,6 +730,9 @@
             currentAppointment.status = 'pending';
             saveData();
             updateStats();
+            sb.from('appointments').update({date: newDate, time: newTime, status: 'pending'}).eq('id', currentAppointment.id).then(({ error }) => {
+                if (error) console.error(error);
+            });
             alert(`予約を変更しました。新しい日時: ${newDate} ${newTime}`);
             document.getElementById('searchResults').classList.add('hidden');
         }
@@ -720,6 +742,9 @@
                 currentAppointment.status = 'cancelled';
                 saveData();
                 updateStats();
+                sb.from('appointments').update({status: 'cancelled'}).eq('id', currentAppointment.id).then(({ error }) => {
+                    if (error) console.error(error);
+                });
                 alert('予約をキャンセルしました。');
                 document.getElementById('searchResults').classList.add('hidden');
             }
@@ -754,16 +779,16 @@
         }
 
         // Initialize
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', async function() {
             const savedSize = parseInt(localStorage.getItem('medibook_fontsize'));
             if (savedSize) {
                 setBaseFontSize(savedSize);
             }
-            // 管理者ページでのみ使用する機能は除外
+            await fetchAppointments();
             updateTime();
             updateStats();
             setInterval(updateTime, 60000); // Update time every minute
-            setInterval(updateStats, 300000); // Update stats every 5 minutes
+            setInterval(async () => { await fetchAppointments(); updateStats(); }, 300000); // every 5 minutes
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- keep admin login state using localStorage
- integrate Supabase for storing reservations
- document database setup in README

## Testing
- `npm --version`
- `node -e "console.log('node test')"`

------
https://chatgpt.com/codex/tasks/task_e_684dfa1db898832e8c698d1e8962d210