### PR TITLE
Fix Supabase URL for appointments

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ medibook/
 
 予約データは [Supabase](https://supabase.com/) の無料プランでクラウド保存できます。
 静的ホスティングから直接DBへ接続しないよう、Supabase Edge Functions を利用する構成に変更しました。
-`FUNCTION_URL` 定数に、ご自身のプロジェクトでデプロイした Edge Function の URL を設定してください。関数のサンプル実装は `supabase/functions/appointments/index.ts` に含まれています。
+`FUNCTION_URL` 定数に、ご自身のプロジェクトでデプロイした Edge Function の URL を設定してください。例えば `https://<your-project-ref>.functions.supabase.co/appointments` のようになります。関数のサンプル実装は `supabase/functions/appointments/index.ts` に含まれています。
 詳細なセットアップ手順は [SUPABASE_SETUP.md](SUPABASE_SETUP.md) を参照してください。無料枠の範囲内であれば月額0円で利用可能です。
 
 ## ライセンス

--- a/admin/index.html
+++ b/admin/index.html
@@ -573,7 +573,7 @@
 
     <script>
         // Supabase Edge Function のエンドポイントURL
-        const FUNCTION_URL = 'https://mdzpjdugshzyjmskjgkt.supabase.co/functions/v1/appointments';
+        const FUNCTION_URL = 'https://mdzpjdugshzyjmskjgkt.functions.supabase.co/appointments';
 
         // Data Storage
         let appointments = [];

--- a/index.html
+++ b/index.html
@@ -451,7 +451,7 @@
 
     <script>
         // Supabase Edge Function のエンドポイントURL
-        const FUNCTION_URL = 'https://mdzpjdugshzyjmskjgkt.supabase.co/functions/v1/appointments';
+        const FUNCTION_URL = 'https://mdzpjdugshzyjmskjgkt.functions.supabase.co/appointments';
 
         // Data Storage
         let appointments = [];


### PR DESCRIPTION
## Summary
- point FUNCTION_URL to functions.supabase.co
- document example Edge Function URL in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e4724f5ac832e9cf16ccfddcb4159