### PR TITLE
Remove developer section from footer

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -536,7 +536,7 @@
     <!-- Footer -->
     <footer class="medical-gradient text-white py-8">
         <div class="container mx-auto px-4">
-            <div class="grid md:grid-cols-3 gap-8">
+            <div class="grid md:grid-cols-2 gap-8">
                 <div>
                     <div class="flex items-center space-x-3 mb-4">
                         <i class="fas fa-heartbeat text-2xl"></i>
@@ -551,17 +551,6 @@
                         <div><a href="terms.html" class="hover:text-white">免責事項</a></div>
                         <div><a href="contact.html" class="hover:text-white">お問い合わせ</a></div>
                         <div><a href="usage.html" class="hover:text-white">使い方</a></div>
-                    </div>
-                </div>
-                <div>
-                    <h4 class="font-semibold mb-4">開発者</h4>
-                    <div class="text-blue-200">
-                        <div>30日連続開発チャレンジ</div>
-                        <div class="mt-2">
-                            <a href="https://x.com/appadaycreator" target="_blank" class="hover:text-white">
-                                <i class="fab fa-x-twitter mr-2"></i>@appadaycreator
-                            </a>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -414,7 +414,7 @@
     <!-- Footer -->
     <footer class="medical-gradient text-white py-8">
         <div class="container mx-auto px-4">
-            <div class="grid md:grid-cols-3 gap-8">
+            <div class="grid md:grid-cols-2 gap-8">
                 <div>
                     <div class="flex items-center space-x-3 mb-4">
                         <i class="fas fa-heartbeat text-2xl"></i>
@@ -429,17 +429,6 @@
                         <div><a href="terms.html" class="hover:text-white">免責事項</a></div>
                         <div><a href="contact.html" class="hover:text-white">お問い合わせ</a></div>
                         <div><a href="usage.html" class="hover:text-white">使い方</a></div>
-                    </div>
-                </div>
-                <div>
-                    <h4 class="font-semibold mb-4">開発者</h4>
-                    <div class="text-blue-200">
-                        <div>30日連続開発チャレンジ</div>
-                        <div class="mt-2">
-                            <a href="https://x.com/appadaycreator" target="_blank" class="hover:text-white">
-                                <i class="fab fa-x-twitter mr-2"></i>@appadaycreator
-                            </a>
-                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- プライマリページと管理者ページのフッターから開発者情報を削除
- 不要となった3カラム設定を2カラムに変更

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684e5c973474832eb3a8f85ebb371cd6