### PR TITLE
Fix timestamp column name

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -691,7 +691,7 @@
                 visitType: document.getElementById('visitType').value,
                 symptoms: document.getElementById('symptoms').value || '特になし',
                 status: 'pending',
-                createat: new Date().toISOString()
+                createdAt: new Date().toISOString()
             };
 
             // Validation

--- a/index.html
+++ b/index.html
@@ -557,7 +557,7 @@
                 visitType: document.getElementById('visitType').value,
                 symptoms: document.getElementById('symptoms').value || '特になし',
                 status: 'pending',
-                createat: new Date().toISOString()
+                createdAt: new Date().toISOString()
             };
 
             // Validation


### PR DESCRIPTION
## Summary
- correct the timestamp field to `createdAt` in both user and admin booking forms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f3a129aac832eb135cf9ba2739643